### PR TITLE
chore: version bump of libphonenumber-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "classnames": "^2.2.5",
-    "libphonenumber-js-utils": "https://github.com/reaphq/libphonenumber-js-utils.git#d76416c17ddcdd3c939280271b8a91ab3ad7c0be",
+    "libphonenumber-js-utils": "https://github.com/reaphq/libphonenumber-js-utils.git#139085b16f75276478f28e591d64f15598cfcd49",
     "prop-types": "^15.6.1",
     "react-style-proptype": "^3.0.0",
     "underscore.deferred": "^0.4.0"

--- a/src/components/__tests__/TelInput.test.js
+++ b/src/components/__tests__/TelInput.test.js
@@ -511,4 +511,25 @@ describe('TelInput', function() {
       expect(changedInputComponent.props().value).toBe('+886912345678')
     })
   })
+
+  it('validates a real Hong Kong phone number', () => {
+    this.params = {
+      ...this.params,
+      defaultCountry: 'hk',
+      nationalMode: true,
+      value: '9390 7970',
+    }
+    const subject = this.makeSubject()
+
+    expect(this.params.defaultCountry).toBe('hk')
+
+    // Verify that the country is correctly set to Hong Kong
+    expect(subject.instance().selectedCountryData.iso2).toBe('hk')
+    expect(subject.instance().selectedCountryData.name).toBe('Hong Kong (香港)')
+    expect(subject.instance().selectedCountryData.dialCode).toBe('852')
+
+    // Test with a valid HK mobile number format (8 digits starting with 5, 6, or 9)
+    expect(subject.instance().isValidNumber('9390 7970')).toBe(true)
+    expect(subject.instance().isValidNumber('12345')).toBe(false)
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -15603,14 +15603,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libphonenumber-js-utils@https://github.com/reaphq/libphonenumber-js-utils.git#d76416c17ddcdd3c939280271b8a91ab3ad7c0be":
-  version: 8.12.51
-  resolution: "libphonenumber-js-utils@https://github.com/reaphq/libphonenumber-js-utils.git#commit=d76416c17ddcdd3c939280271b8a91ab3ad7c0be"
+"libphonenumber-js-utils@https://github.com/reaphq/libphonenumber-js-utils.git#139085b16f75276478f28e591d64f15598cfcd49":
+  version: 9.0.7
+  resolution: "libphonenumber-js-utils@https://github.com/reaphq/libphonenumber-js-utils.git#commit=139085b16f75276478f28e591d64f15598cfcd49"
   dependencies:
     "@node-minify/core": "npm:^6.2.0"
     "@node-minify/google-closure-compiler": "npm:^6.2.0"
     filterxml: "npm:^1.1.4"
-  checksum: 10/5f7a752ffebcfecf7b3e41087d30ffc9f792d9d93cba2016094a5fa9906e89afe93f1e9579fab65891482e37fd0799d22b3db880a04739c5e0280d1eeae6bc57
+  checksum: 10/b7f7604ab4621a6d0593468a89c6a9ea9b245d059c0a66278e2dd1f1a35795d69b6a23126ab32b9450660ae1b45fd85690201dc5d645bc6d02dfda1347d7db1d
   languageName: node
   linkType: hard
 
@@ -20450,7 +20450,7 @@ __metadata:
     jasmine-reporters: "npm:^2.2.0"
     jest: "npm:^23.6.0"
     jsdom: "npm:^9.2.1"
-    libphonenumber-js-utils: "https://github.com/reaphq/libphonenumber-js-utils.git#d76416c17ddcdd3c939280271b8a91ab3ad7c0be"
+    libphonenumber-js-utils: "https://github.com/reaphq/libphonenumber-js-utils.git#139085b16f75276478f28e591d64f15598cfcd49"
     lint-staged: "npm:^11.1.1"
     packwatch: "npm:^1.0.0"
     prettier: "npm:^1.14.2"


### PR DESCRIPTION
This pull request includes an update to the `libphonenumber-js-utils` dependency in `package.json` and adds a new test case to validate Hong Kong phone numbers in the `TelInput` component test suite.

### Dependency update:
* Updated the `libphonenumber-js-utils` dependency in `package.json` to a newer commit hash, ensuring the latest features and bug fixes are included.

### Test improvements:
* Added a new test case in `TelInput.test.js` to validate Hong Kong phone numbers. The test ensures the correct country data is set (e.g., ISO code, name, dial code) and verifies the validity of a valid HK mobile number format.## Description
bumping version to 8.12.57

## Screenshots (if appropriate):
<!--- If possible, please attach the screenshots (you can use recordit.co to record as GIFs) --->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have used ESLint & Prettier to follow the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
